### PR TITLE
added erebor.douban.com to ad whitelist。

### DIFF
--- a/config/ad_blank.conf
+++ b/config/ad_blank.conf
@@ -25,3 +25,4 @@ t10.baidu.com
 t11.baidu.com
 t12.baidu.com
 tools.3g.qq.com
+erebor.douban.com


### PR DESCRIPTION
屏蔽此域名的情况下ios豆瓣电影APP无法预览预告片，所以建议加入白名单。